### PR TITLE
Fix discovering stacktraces with timestamps

### DIFF
--- a/ext/agent/helpers/helpers.go
+++ b/ext/agent/helpers/helpers.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"signal/models"
 	"strconv"
@@ -61,7 +61,7 @@ func CollectLogsForAnalysis(containerID string, dockerClient *client.Client) ([]
 	}
 	defer logs.Close()
 
-	logBytes, err := ioutil.ReadAll(logs)
+	logBytes, err := io.ReadAll(logs)
 	if err != nil {
 		return nil, err
 	}

--- a/ext/agent/helpers/helpers.go
+++ b/ext/agent/helpers/helpers.go
@@ -43,7 +43,7 @@ func ListContainers(cli *client.Client) ([]types.Container, error) {
 }
 
 func CollectLogsForAnalysis(containerID string, dockerClient *client.Client) ([]models.LogEntry, error) {
-	const MaxLogTail = 8
+	const MaxLogTail = 50
 	const LogStringBuffer = 8
 	const LogTimestampParsingTemplate = "2006-01-02T15:04:05.000000000Z"
 


### PR DESCRIPTION
We had and issue with the agent, the log tail coverage was too short. I fixed that using better timestamp parsing and comparison longer tail and less error keywords to catch only expected error level logs.